### PR TITLE
Document stale-state mitigation hooks in OddsPortal scraper

### DIFF
--- a/oddsportal_scraper.py
+++ b/oddsportal_scraper.py
@@ -494,6 +494,8 @@ class OddsPortalScraper:
 
         1. Sets no-cache/no-store HTTP headers for this navigation only.
         2. Appends a _t=<timestamp> cache-buster to the URL (before the fragment).
+        3. Used by match-page navigation to emulate a fresh/incognito-style load
+           as closely as server behavior allows.
         """
         # --- Build cache-busted URL ---
         # Split on '#' first so the fragment stays at the end.
@@ -524,7 +526,11 @@ class OddsPortalScraper:
             await page.set_extra_http_headers({})
 
     async def _clear_browser_state(self) -> None:
-        """Clear cookies, web storage, cache storage, and service workers from the active context."""
+        """Clear cookies, web storage, cache storage, and service workers from the active context.
+
+        This method is a best-effort stale-state mitigation and is used by
+        retry paths when a previous attempt may have loaded outdated client state.
+        """
         if not self.context:
             logger.debug("⚠️ _clear_browser_state: no active context, skipping")
             return
@@ -4375,4 +4381,3 @@ def scrape_multiple_matches_parallel_sync(tasks: List[Dict], num_browsers: int =
         f"(entries in results dict={len(all_results)})"
     )
     return all_results
-


### PR DESCRIPTION
### Motivation
- Make the scraper's existing stale-data mitigation logic easier to audit and reason about by documenting the intent and role of the main incognito/cache-defeat helpers used during match navigation and retries.

### Description
- Expanded docstrings in `oddsportal_scraper.py` to clarify that `_goto_fresh()` performs per-navigation cache-busting and is used to emulate a fresh/incognito-style load, and that `_clear_browser_state()` is a best-effort stale-state cleanup used by retry paths; no runtime behavior was changed.

### Testing
- Verified the change is syntactically valid by running `python -m py_compile oddsportal_scraper.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c00ef4f88333864f5c3598c663e0)